### PR TITLE
Correct key weight

### DIFF
--- a/templates/documentation/template.md
+++ b/templates/documentation/template.md
@@ -333,7 +333,7 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
+| `0x01`  | 1      | 1000   |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130">](https://github.com/onflow/flow-go-sdk/tree/master/examples#single-party-single-signature)**
 ```
@@ -345,12 +345,12 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 - Proposer, payer and authorizer are the same account (`0x01`).
 - Only the envelope must be signed.
-- Each key has weight 0.5, so two signatures are required.
+- Each key has weight 500, so two signatures are required.
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130">](https://github.com/onflow/flow-go-sdk/tree/master/examples#single-party-multiple-signatures)**
 ```
@@ -367,8 +367,8 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
-| `0x02`  | 3      | 1.0    |
+| `0x01`  | 1      | 1000   |
+| `0x02`  | 3      | 1000   |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130">](https://github.com/onflow/flow-go-sdk/tree/master/examples#multiple-parties)**
 ```
@@ -386,8 +386,8 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 1.0    |
-| `0x02`  | 3      | 1.0    |
+| `0x01`  | 1      | 1000   |
+| `0x02`  | 3      | 1000   |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130">](https://github.com/onflow/flow-go-sdk/tree/master/examples#multiple-parties-two-authorizers)**
 ```
@@ -405,10 +405,10 @@ Flow supports great flexibility when it comes to transaction signing, we can def
 
 | Account | Key ID | Weight |
 | ------- | ------ | ------ |
-| `0x01`  | 1      | 0.5    |
-| `0x01`  | 2      | 0.5    |
-| `0x02`  | 3      | 0.5    |
-| `0x02`  | 4      | 0.5    |
+| `0x01`  | 1      | 500    |
+| `0x01`  | 2      | 500    |
+| `0x02`  | 3      | 500    |
+| `0x02`  | 4      | 500    |
 
 **[<img src="https://raw.githubusercontent.com/onflow/sdks/main/templates/documentation/try.svg" width="130">]()** // TODO example link
 ```

--- a/templates/documentation/template.md
+++ b/templates/documentation/template.md
@@ -138,7 +138,7 @@ Retrieve events by a given type in a specified block height range or through a l
 A.{contract address}.{contract name}.{event name}
 ```
 
-Please read more about [events in the documentation](https://docs.onflow.org/core-contracts/flow-token/). The exception to this standard are 
+Please read more about [events in the documentation](https://docs.onflow.org/cadence/language/core-events/). The exception to this standard are 
 core events, and you should read more about them in [this document](https://docs.onflow.org/cadence/language/core-events/).
 
 📖 **Block height range** expresses the height of the start and end block in the chain.


### PR DESCRIPTION
1. Some documents are using 0.1 and 1.0 as key weight, which should be in the range of [1, 1000].
This change help with issue [onflow/flow#473](https://github.com/onflow/flow/issues/473)
2. fix a wrong link in event