### PR TITLE
Avoid requiring unnecessary hex-encoding and using decodeHex

### DIFF
--- a/templates/cadence/add-contract.cdc
+++ b/templates/cadence/add-contract.cdc
@@ -1,5 +1,5 @@
 transaction(name: String, code: String) {
 	prepare(signer: AuthAccount) {
-		signer.contracts.add(name: name, code: code.decodeHex())
+		signer.contracts.add(name: name, code: code.utf8)
 	}
 }

--- a/templates/cadence/create-account-simple.cdc
+++ b/templates/cadence/create-account-simple.cdc
@@ -20,7 +20,7 @@ transaction(publicKeys: [String], sigAlgos: [SignatureAlgorithm], hashAlgos: [Ha
 		}
 
 		for contract in contracts.keys {
-			acct.contracts.add(name: contract, code: contracts[contract]!.decodeHex())
+			acct.contracts.add(name: contract, code: contracts[contract]!.utf8)
 		}
 	}
 }

--- a/templates/cadence/create-account.cdc
+++ b/templates/cadence/create-account.cdc
@@ -8,11 +8,10 @@ transaction(publicKeys: [Crypto.KeyListEntry], contracts: {String: String}) {
 		for key in publicKeys {
 			account.keys.add(publicKey: key.publicKey, hashAlgorithm: key.hashAlgorithm, weight: key.weight)
 		}
-		
+
 		// add contracts if provided
 		for contract in contracts.keys {
-			account.contracts.add(name: contract, code: contracts[contract]!.decodeHex())
+			account.contracts.add(name: contract, code: contracts[contract]!.utf8)
 		}
 	}
 }
- 

--- a/templates/cadence/create-and-fund-account.cdc
+++ b/templates/cadence/create-and-fund-account.cdc
@@ -16,7 +16,7 @@ transaction(publicKeys: [Crypto.KeyListEntry], contracts: {String: String}, fund
 
 		// add contracts if provided
 		for contract in contracts.keys {
-			account.contracts.add(name: contract, code: contracts[contract]!.decodeHex())
+			account.contracts.add(name: contract, code: contracts[contract]!.utf8)
 		}
 
 		self.tokenReceiver = account

--- a/templates/cadence/update-contract.cdc
+++ b/templates/cadence/update-contract.cdc
@@ -1,5 +1,5 @@
 transaction(name: String, code: String) {
 	prepare(signer: AuthAccount) {
-		signer.contracts.update__experimental(name: name, code: code.decodeHex())
+		signer.contracts.update__experimental(name: name, code: code.utf8)
 	}
 }


### PR DESCRIPTION
*NOTE:* This is a breaking change, users of this repo will need to remove hex-encoding of the code and instead pass the code as-is.